### PR TITLE
Fixes UCB Person Page custom modules

### DIFF
--- a/ucb_article_author.module
+++ b/ucb_article_author.module
@@ -2,24 +2,30 @@
 
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\taxonomy\Entity\Term;
+use Drupal\node\Entity\Node;
 
 /**
- * Implements hook_node_insert().
+ * Implements hook_taxonomy_term_insert().
  */
-function ucb_article_author_node_insert(EntityInterface $node) {
-  // Check if the inserted entity is of the 'Person Page' content type.
-  if ($node->getEntityTypeId() === 'node' && $node->bundle() === 'ucb_person') {
-    // Extract the first and last name from the entity's title.
-    $title = $node->getTitle();
-    // Create a taxonomy term using the extracted name.
-    $term = Term::create([
-      'vid' => 'byline',
-      'name' => $title,
-      'field_author_person_page' => [
-        'target_id' => $node->id(),
-      ],
-    ]);
-    // Save the taxonomy term to update the entity reference field.
-    $term->save();
+function ucb_article_author_taxonomy_term_insert(EntityInterface $term) {
+  // Check if the inserted term is a 'byline' taxonomy term
+  if ($term->getEntityTypeId() === 'taxonomy_term' && $term->bundle() === 'byline') {
+    $term_name = $term->getName();
+
+    // Query to find a 'ucb_person' node with the same title.
+    $query = \Drupal::entityQuery('node')
+      ->condition('type', 'ucb_person')
+      ->condition('title', $term_name)
+      ->range(0, 1)  // We only need the first result.
+      ->accessCheck(FALSE);  // Skip access checks, needed or WSOD
+
+    $node_ids = $query->execute();
+
+    // If a 'ucb_person' node with the same title is found.
+    if (!empty($node_ids)) {
+      $node_id = reset($node_ids);
+      $term->set('field_author_person_page', ['target_id' => $node_id]);
+      $term->save();
+    }
   }
 }

--- a/ucb_article_author.module
+++ b/ucb_article_author.module
@@ -9,10 +9,8 @@ use Drupal\taxonomy\Entity\Term;
 function ucb_article_author_node_insert(EntityInterface $node) {
   // Check if the inserted entity is of the 'Person Page' content type.
   if ($node->getEntityTypeId() === 'node' && $node->bundle() === 'ucb_person') {
-
     // Extract the first and last name from the entity's title.
     $title = $node->getTitle();
-
     // Create a taxonomy term using the extracted name.
     $term = Term::create([
       'vid' => 'byline',
@@ -21,12 +19,7 @@ function ucb_article_author_node_insert(EntityInterface $node) {
         'target_id' => $node->id(),
       ],
     ]);
-
     // Save the taxonomy term to update the entity reference field.
     $term->save();
   }
 }
-
-
-?>
-


### PR DESCRIPTION
Adds the fixed versions of `UCB Person Title` and `UCB Article Author` to template and profile. Allows First and Last Name fields to create a Person Page title, getting rid of the need to enter a title for these pages. Also automatically creates a Byline taxonomy for newly created Person Pages, for use in the Byline field. 

Includes:

- `tiamat10-project-template` => https://github.com/CuBoulder/tiamat10-project-template/pull/15 (`issue/ucb_person_title/2`)
-  `tiamat-profile` => https://github.com/CuBoulder/tiamat10-profile/pull/28 (`issue/ucb_person_title/2`)
-  `ucb_person_title` => https://github.com/CuBoulder/ucb_person_title/pull/4 (`issue/2`)
-  `ucb_article_author` => https://github.com/CuBoulder/ucb_article_author/pull/2 (`issue/1`)

Resolves https://github.com/CuBoulder/ucb_article_author/issues/1, Resolves https://github.com/CuBoulder/ucb_person_title/issues/2